### PR TITLE
"Thumbnail" display of video

### DIFF
--- a/src/video-display/video-display-360.js
+++ b/src/video-display/video-display-360.js
@@ -1,5 +1,9 @@
 (function($, window, Player){
-    
+
+    var _videoElement = function() {
+        return Player.get("videoElement");
+    }
+
     var _loadAframe = function(callback){
         $.ajax({
             url: "//aframe.io/releases/0.2.0/aframe.min.js",
@@ -14,7 +18,7 @@
         };
         checkAframeLoaded();
     };
-    
+
     var _display360 = function(callback){
         console.log("localhost");
         if(typeof AFRAME == "undefined"){
@@ -25,13 +29,12 @@
             _activate360(callback);
         }
     };
-    
+
     var _activate360 = function(callback){
         var scene = $("<div></div>");
         Player.modules[0].render(function(){
-            
-            var ve = Player.get("videoElement");
-            ve.video.attr({
+
+            _videoElement().video.attr({
                 "id": "videoElement",
                 "preload": "none",
                 "crossorigin": "anonymous"
@@ -39,16 +42,39 @@
                 "webkit-playsinline": true,
                 "autoplay": false
             }).get(0).load();
-            
-            scene.find("a-assets").append(ve.video);
-            ve.container.append(scene);
-            
+
+            var elmAssets = scene.find("a-assets");
+            elmAssets.append(_videoElement().video);
+            elmAssets.append(_build360ThumbnailAsset());
+            _videoElement().container.append(scene);
+            _videoElement().video.bind("play", _playing360);
+
             window.setTimeout(callback, 500);
-            
+
         }, "video-display/video-display-360.liquid", scene.get(0));
-        
+
     }
-    
+
+    var _build360ThumbnailAsset = function() {
+     var elmAsset = $('<img />');
+      elmAsset.attr({
+        src: _getHDPoster,
+        id: "thumbnailElement"
+      });
+      return elmAsset;
+    }
+
+    var _getHDPoster = function() {
+     var poster = _videoElement().getPoster();
+      return poster.replace("large", "1920x1080cr");
+    }
+
+    var _playing360 = function() {
+     _videoElement().container.find('a-sky').attr('visible', false);
+     _videoElement().container.find('a-videosphere').attr('visible', true);
+    }
+
+
     window.display360 = _display360;
-    
+
 })(jQuery, window, Player);


### PR DESCRIPTION
* A-Frame renders both a video and a 360 panorama (taken from the video poster)
* The panorama is initially visible, the video is initially hidden
* When the the video is played, the panorama image is hidden and the video made visible
* This is for the benefit of mobile browsers, where the video is not loaded until the user choses to play it - hence the thumbnail cannot be taken from the video's first frame.