### PR TITLE
fix(subtitles) show on load [VMP-288]

### DIFF
--- a/src/subtitles/subtitles.js
+++ b/src/subtitles/subtitles.js
@@ -316,7 +316,7 @@ Player.provide('subtitles',
                 $this.audioDescriptionTracks[o.locale] = o;
               }
             });
-            Player.set('subtitleLocale', (!!$this.defaultLocale ? $this.defaultLocale : ''));
+            Player.set('subtitleLocale', (!!$this.defaultLocale && !!$this.subtitlesOnByDefault ? $this.defaultLocale : ''));
             Player.set('audioDescriptionLocale', $this.defaultAudioDescripionLocale);
             $this.pendingSubtitleTracks = true;
             Player.fire('player:subtitlechange');


### PR DESCRIPTION
Enforcing `subtitlesOnByDefault` when loading subtitles and setting the `subtitleLocale`

Fixes [VMP-288](https://twentythreecom.atlassian.net/browse/VMP-288)