### PR TITLE
fix(context-menu): add missing ? in link to twentythree and change to .com

### DIFF
--- a/src/context-menu/context-menu.liquid
+++ b/src/context-menu/context-menu.liquid
@@ -35,10 +35,9 @@
         <li class="divider"></li>
       {% endif %}
       <li><a href="{{url}}/debug?{{debugParameters}}" target="_new" click="$set:showMenu:false">{{"debug_information"|translate}}</a></li>
-      <li><a href="https://www.twentythree.net/help?utm_source=product&utm_medium=referral&utm_campaign=player-help-links" target="_new" click="$set:showMenu:false">{{"help_center"|translate}}</a></li>
-      <li><a href="https://www.twentythree.net/help/power-mode/configure-players?utm_source=product&utm_medium=referral&utm_campaign=player-help-links" target="_new" click="$set:showMenu:false">{{"twentythree_players"|translate}}</a></li>
-      <li><a href="https://www.twentythree.net/utm_source=product&utm_medium=referral&utm_campaign=player-about-links" target="_new" click="$set:showMenu:false">{{"about_twentythree"|translate}}</a></li>
+      <li><a href="https://www.twentythree.com/help?utm_source=product&utm_medium=referral&utm_campaign=player-help-links" target="_new" click="$set:showMenu:false">{{"help_center"|translate}}</a></li>
+      <li><a href="https://www.twentythree.com/help/power-mode/configure-players?utm_source=product&utm_medium=referral&utm_campaign=player-help-links" target="_new" click="$set:showMenu:false">{{"twentythree_players"|translate}}</a></li>
+      <li><a href="https://www.twentythree.com/?utm_source=product&utm_medium=referral&utm_campaign=player-about-links" target="_new" click="$set:showMenu:false">{{"about_twentythree"|translate}}</a></li>
     </ul>
   {% endif %}
 {% endif %}
-


### PR DESCRIPTION
The 'About TwentyThree' link was missing a '?' for the parameters sent. 
... and the links have been changed to .com 
