### PR TITLE
fix(player): tray nudged further when blocked to remain hidden [PRO-479]

### DIFF
--- a/src/design/design.css
+++ b/src/design/design.css
@@ -170,7 +170,7 @@ ul.button-menu-selection li.selected:hover button { color: #FFFFFF; }
     opacity: 1;
 }
 .block-tray #tray {
-    bottom: -40px !important;
+    bottom: -41px !important;
 }
 .persist-tray #tray {
     bottom: 0 !important;
@@ -219,7 +219,7 @@ ul.button-menu-selection li.selected:hover button { color: #FFFFFF; }
 
 /* === Module: Scrubber === */
 .scrubber-container {
-    position:relative; 
+    position:relative;
     height:40px;
 }
 .scrubber {
@@ -325,10 +325,10 @@ ul.button-menu-selection li.selected:hover button { color: #FFFFFF; }
     margin-right: 70px;
 }
 .section {
-    position:absolute; 
+    position:absolute;
     top:0;
     width:4px;
-    height:4px; 
+    height:4px;
     margin-left: -2px;
     background: rgb(255,255,255);
     background: rgba(255,255,255,0.72);


### PR DESCRIPTION
The video scrubber was still visible when hovering the bottom of the player when the tray is disabled
