### PR TITLE
fix: adding no-repeat for the ad icons

### DIFF
--- a/src/design/design.css
+++ b/src/design/design.css
@@ -860,12 +860,14 @@ body.overlay-shown .button-container-share {
     background-image: linear-gradient(transparent, transparent), url('audiodescription.svg');
     background-size: 30px;
     background-position: center center;
+    background-repeat: no-repeat;
 }
 .audiodescription-button .audiodescription-active-icon {
     background-image: url('audiodescription.png');
     background-image: linear-gradient(transparent, transparent), url('audiodescription.svg');
     background-size: 30px;
     background-position: center center;
+    background-repeat: no-repeat;
 }
 .slides-button  {
     background-image: url('slides.png');


### PR DESCRIPTION
On the paleo version of the player parts of the repeated AD icons are visible. This problem is not coming up for the rest of the versions, but I thought we should keep this consistent.