### PR TITLE
feat(slider & gallery): improved labels for the slider and added player galleries

### DIFF
--- a/src/design/design.css
+++ b/src/design/design.css
@@ -48,7 +48,7 @@
   --big-play-height: 51px;
   --big-play-border-radius: var(--menu-border-radius);
 
-  --outline: 3px solid #aaa;
+  --outline: 3px solid #fff;
 }
 
 

--- a/src/gallery-before.html
+++ b/src/gallery-before.html
@@ -1,0 +1,36 @@
+<style>
+ body {
+   font-family:Helvetica;
+ }
+ body>div {
+   display:flex;
+   gap:1em;
+ }
+ div>div {
+   flex:1;
+
+ }
+ div iframe {
+   width:520px;
+   height:292px;
+   border:0;
+   margin-bottom:1em;
+ }
+</style>
+
+<body>
+  <div>
+    <div>
+      <h3>Squares</h3>
+      <iframe loading="lazy" src="https://video.twentythree.com/glue-squares.ihtml/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=baseline" allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy" src="https://video.twentythree.com/glue-squares.ihtml/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=baseline&socialSharing=0" allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy" src="https://video.twentythree.com/glue-squares.ihtml/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&theme=baseline" allow="autoplay; defullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Eve</h3>
+      <iframe loading="lazy" src="https://video.twentythree.com/glue-eve.ihtml/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&scrubberColor=%23052F5F" allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy" src="https://video.twentythree.com/glue-eve.ihtml/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&scrubberColor=%23052F5F" allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy" src="https://video.twentythree.com/glue-eve.ihtml/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&scrubberColor=%23052F5F" allow="autoplay; fullscreen"></iframe>
+    </div>
+  </div>
+</body>

--- a/src/gallery-bigplay.html
+++ b/src/gallery-bigplay.html
@@ -1,0 +1,62 @@
+<style>
+  body {
+    font-family: Helvetica;
+  }
+
+  body>div {
+    display: flex;
+    gap: 1em;
+  }
+
+  div>div {
+    flex: 1;
+
+  }
+
+  div iframe {
+    width: 520px;
+    height: 292px;
+    border: 0;
+    margin-bottom: 1em;
+  }
+</style>
+
+<body>
+  <div>
+    <div>
+      <h3>Traditional</h3>
+      <iframe loading="lazy" src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayPosition=bottomLeft&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayPosition=bottomLeft&bigPlayForPause=1&showTray=0&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Lax</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayStyle=lax&bigPlayPosition=bottomLeft&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayStyle=lax&bigPlayPosition=bottomLeft&bigPlayForPause=1&showTray=0&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayStyle=lax&bigPlayPosition=bottomRight&bigPlayForPause=1&showTray=0&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Circle</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayStyle=circle&bigPlayPosition=bottomRight&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayStyle=circle&bigPlayPosition=bottomRight&bigPlayForPause=1&showTray=0&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&autoPlay=0&bigPlayStyle=circle&bigPlayPosition=bottomLeft&bigPlayForPause=1&showTray=0&enableSubtitles=0"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+  </div>
+</body>

--- a/src/gallery.html
+++ b/src/gallery.html
@@ -1,0 +1,114 @@
+<style>
+  body {
+    font-family: Helvetica;
+  }
+
+  body>div {
+    display: flex;
+    gap: 1em;
+  }
+
+  div>div {
+    flex: 1;
+
+  }
+
+  div iframe {
+    width: 520px;
+    height: 292px;
+    border: 0;
+    margin-bottom: 1em;
+  }
+</style>
+
+<body>
+  <div>
+    <div>
+      <h3>Baseline</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=baseline"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=baseline&socialSharing=0"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&mutedAutoPlay=0&autoPlay=1&theme=baseline"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Rounded</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=rounded&scrubberColor=%23052F5F&borderRadius=10"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=rounded&socialSharing=0&scrubberColor=%23052F5F&borderRadius=10"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&theme=rounded&scrubberColor=%23052F5F&borderRadius=10"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Hip</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=hip&scrubberColor=%233000FF"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=hip&socialSharing=0&scrubberColor=%233000FF"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&theme=hip&scrubberColor=%233000FF"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Circular</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=circular&scrubberColor=%23E1241B"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=circular&socialSharing=0&scrubberColor=%23E1241B"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&theme=circular&scrubberColor=%23E1241B"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Cinematic</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=cinematic&scrubberColor=%233000FF"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=cinematic&socialSharing=0&scrubberColor=%233000FF"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&theme=cinematic&scrubberColor=%233000FF"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Angelic</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=angelic&scrubberColor=%23E1241B"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=0&autoPlay=0&theme=angelic&socialSharing=0&scrubberColor=%23E1241B"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&mutedAutoPlay=1&autoPlay=1&theme=angelic&scrubberColor=%23E1241B"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+    <div>
+      <h3>Color burst</h3>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=colorburst&scrubberColor=%23052F5F"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=colorburst&scrubberColor=%23FF0000"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=colorburst&scrubberColor=%2300FF00"
+        allow="autoplay; fullscreen"></iframe>
+      <iframe loading="lazy"
+        src="/player/src/player.html?domain=video.twentythree.com&alwaysShowTray=1&autoPlay=0&theme=colorburst&scrubberColor=%230000FF"
+        allow="autoplay; fullscreen"></iframe>
+    </div>
+  </div>
+</body>

--- a/src/player.html
+++ b/src/player.html
@@ -14,7 +14,6 @@
     <link rel="stylesheet" type="text/css" href="big-play-button/big-play-button.css" />
     <link rel="stylesheet" type="text/css" href="loop/loop.css" />
     <link rel="stylesheet" type="text/css" href="actions/actions.css" />
-    <link rel="stylesheet" type="text/css" href="accessibility/accessibility.css" />
     <link rel="stylesheet" type="text/css" href="protection/protection.css" />
     <link rel="stylesheet" type="text/css" href="slides/slides.css" />
     <link rel="stylesheet" type="text/css" href="sections-menu/sections-menu.css" />

--- a/src/scrubber/scrubber.js
+++ b/src/scrubber/scrubber.js
@@ -103,7 +103,7 @@ Player.provide('scrubber',
             $(".scrubber, .sections").css({
               marginRight: $this.timeContainer.width() + 10
             });
-            $('.scrubber-track').attr('aria-valuetext', formatTimeToReadable(Player.get('displayPlayProgress')))
+            $('.scrubber-track').attr('aria-valuetext', formatTimeToReadable(Player.get('displayPlayProgress')) + ' of ' + formatTimeToReadable(Player.get('duration')))
             break;
           case 'dvr':
             $this.bufferContainer.css({
@@ -233,5 +233,5 @@ Player.provide('scrubber',
 );
 
 Player.translate("seek_slider",{
-  en: "Seek slider"
+  en: "Video player slider"
 });

--- a/src/video-display/video-display.js
+++ b/src/video-display/video-display.js
@@ -909,18 +909,18 @@ var formatTimeToReadable = function(time){
 
   minute = Math.floor(time/60).toString();
   if(Math.floor(time/60).toString() == 1){
-    minute += 'min';
+    minute += Player.translate('min');
   }else if (Math.floor(time/60).toString() > 1){
-    minute += 'mins';
+    minute += Player.translate('mins');
   } else {
     minute = '';
   }
 
   second = Math.round(time%60).toString();
   if(Math.round(time%60).toString() == 1){
-    second += 'sec';
+    second += Player.translate('sec');
   }else if (Math.round(time%60).toString() != 1){
-    second += 'secs';
+    second += Player.translate('secs');
   }
 
   return(minute + second);
@@ -954,8 +954,8 @@ Player.translate("mins",{
   en: " minutes "
 });
 Player.translate("sec",{
-  en: "second"
+  en: " second"
 });
 Player.translate("secs",{
-  en: "seconds"
+  en: " seconds"
 });


### PR DESCRIPTION
Following KK's suggestion:
1. Changed 'Seek slider' label to 'Video player slider'
2. Changed time announcement from 'x mins y secs' to 'x minutes y seconds of A minutes B seconds'

Improvement of the contrast of the focus outline:

3. changed the light focus outline from #aaa to #fff for better contrast


Player galleries:

4. added 3 galleries for better overview and testing of different versions of the players

